### PR TITLE
Documentation Updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,25 +33,29 @@ Usage
                             E.g. us-east-1
       --max-snapshots-per-volume SNAPSHOTS
                             the maximum number of snapshots to keep per EBS
-                            volume. The oldest snapshots will be deleted. 
-                            Default: 3
+                            volume. The oldest snapshots will be deleted. Default:
+                            3
       --snapshot-only       Only snapshot EBS volumes, do not remove old snapshots
       --remove-only         Only remove old snapshots, do not create new snapshots
       --verbose, -v         enable verbose output (-vvv for more)
       --version             display version number and exit
-      --tags TAGS [TAGS ...]Only snapshot instances that match passed in tags.
-                            E.g. --tag Name:foo will snapshot all instances that
-                            do not have a `Name` tag with the value `foo`
+      --tags TAGS [TAGS ...]
+                            Only snapshot instances that match passed in tags.
+                            E.g. --tag Name:foo will snapshot all instances with a
+                            tag `Name` and value is `foo`
       --reverse-tags        Do a reverse match on the passed in tags. E.g. --tag
                             Name:foo --reverse-tags will snapshot all instances
                             that do not have a `Name` tag with the value `foo`
       --cross-account-number CROSS_ACCOUNT_NUMBER
-                            Do a cross-account snapshot. Requires that you pass in
-                            the --cross-account-role parameter
+                            Do a cross-account snapshot (this is the account
+                            number to do snapshots on). NOTE: This requires that
+                            you pass in the --cross-account-role parameter. E.g.
+                            --cross-account-number 111111111111 --cross-account-
+                            role Snapshot
       --cross-account-role CROSS_ACCOUNT_ROLE
-                            The role backup-monkey will assume when doing a cross-
-                            account snapshot
-
+                            The name of the role that backup-monkey will assume
+                            when doing a cross-account snapshot. E.g. --cross-
+                            account-role Snapshot
 
 Examples
 --------

--- a/backup_monkey/cli.py
+++ b/backup_monkey/cli.py
@@ -48,9 +48,9 @@ def run():
     parser.add_argument('--reverse-tags', action='store_true', default=False,
                         help='Do a reverse match on the passed in tags. E.g. --tag Name:foo --reverse-tags will snapshot all instances that do not have a `Name` tag with the value `foo`')
     parser.add_argument('--cross-account-number', action='store',
-                        help='Do a cross-account snapshot. Requires that you pass in the --cross-account-role parameter')
+                        help='Do a cross-account snapshot (this is the account number to do snapshots on). NOTE: This requires that you pass in the --cross-account-role parameter. E.g. --cross-account-number 111111111111 --cross-account-role Snapshot')
     parser.add_argument('--cross-account-role', action='store',
-                        help='The role backup-monkey will assume when doing a cross-account snapshot')
+                        help='The name of the role that backup-monkey will assume when doing a cross-account snapshot. E.g. --cross-account-role Snapshot')
 
     args = parser.parse_args()
 

--- a/backup_monkey/core.py
+++ b/backup_monkey/core.py
@@ -38,7 +38,7 @@ class BackupMonkey(object):
             from boto.sts import STSConnection
             import boto
             try:
-                role_arn = 'arn:aws:iam::%s:role/%s' % (cross_account_number, cross_account_role)
+                role_arn = 'arn:aws:iam::%s:role/%s' % (self._cross_account_number, self._cross_account_role)
                 sts = STSConnection()
                 assumed_role = sts.assume_role(role_arn=role_arn, role_session_name='AssumeRoleSession')
                 ret = ec2.connect_to_region(

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
         'Topic :: System :: Installation/Setup',
         'Topic :: Utilities',
     ),


### PR DESCRIPTION
Updated help text for --cross-account-number and --cross-account-role parameters to make it clear that it is the role name we wanted to pass and not the ARN.

Updated README to reflect the above changes

Updated setup.py to include Python 2.7
