### PR TITLE
Bugfix: skip failed volume snapshots

### DIFF
--- a/backup_monkey/core.py
+++ b/backup_monkey/core.py
@@ -142,6 +142,9 @@ class BackupMonkey(object):
             else:
                 return self.get_all_volumes()
     
+    def remove_reserved_tags(self, tags):
+        return dict((key,value) for key, value in tags.iteritems() if not key.startswith('aws:'))
+        
     def snapshot_volumes(self):
         ''' Loops through all EBS volumes and creates snapshots of them '''
 
@@ -163,7 +166,7 @@ class BackupMonkey(object):
             try:
                 snapshot = volume.create_snapshot(description)
                 if volume.tags:
-                    snapshot.add_tags(volume.tags)
+                    snapshot.add_tags(self.remove_reserved_tags(volume.tags))
                 self._info(subject=_status.parse_status('snapshot_create_success', (snapshot.id, volume.id)), 
                     src_volume=volume.id,
                     src_snapshot=snapshot.id,

--- a/tests/unit/test_tags.py
+++ b/tests/unit/test_tags.py
@@ -112,3 +112,16 @@ class TagsTest(TestCase):
         ret = self.backup_monkey.get_volumes_to_snapshot()
         assert len(ret) == 4
         assert ret == [a, match_tag_or_1, b, match_tag_or_2]
+
+    @mock.patch('backup_monkey.core.BackupMonkey.get_connection', side_effect=mock_get_connection)
+    def test_remove_reserved_tags(self, mock):
+        volume_tags = {
+            'a': 'a',
+            'b': 'b',
+            'c': 'c',
+            'aws:a': 'aws:a',
+            'aws:b': 'aws:b'
+        }
+        ret = self.backup_monkey.remove_reserved_tags(volume_tags)
+        assert len(ret) == 3
+        assert ret == { 'a': 'a', 'b': 'b', 'c': 'c' }


### PR DESCRIPTION
Updated codes to skip over failed volume snapshots and proceed with the rest instead of prematurely exiting.
